### PR TITLE
Template inserter selection fixes, where innerBlocks are not selected when a block is added

### DIFF
--- a/src/blocks/accordion/accordion-item/components/edit.js
+++ b/src/blocks/accordion/accordion-item/components/edit.js
@@ -98,6 +98,7 @@ class Edit extends Component {
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
 							template={ TEMPLATE }
+							templateInsertUpdatesSelection={ false }
 						/>
 					</div>
 				</div>

--- a/src/blocks/author/components/edit.js
+++ b/src/blocks/author/components/edit.js
@@ -181,6 +181,7 @@ class Edit extends Component {
 							template={ TEMPLATE }
 							templateLock="all"
 							allowedBlocks={ ALLOWED_BLOCKS }
+							templateInsertUpdatesSelection={ false }
 						/>
 					</div>
 				</div>

--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -142,7 +142,7 @@ const settings = {
 								value={ biography }
 							/>
 						) }
-						<InnerBlocks.Content />
+						<InnerBlocks.Content/>
 					</div>
 				</div>
 			);

--- a/src/blocks/media-card/components/edit.js
+++ b/src/blocks/media-card/components/edit.js
@@ -232,6 +232,7 @@ class Edit extends Component {
 									template={ TEMPLATE }
 									allowedBlocks={ ALLOWED_BLOCKS }
 									templateLock={ true }
+									templateInsertUpdatesSelection={ false }
 								/>
 							) }
 						</div>

--- a/src/blocks/pricing-table/pricing-table-item/components/edit.js
+++ b/src/blocks/pricing-table/pricing-table-item/components/edit.js
@@ -125,6 +125,7 @@ class Edit extends Component {
 						template={ TEMPLATE }
 						templateLock="all"
 						allowedBlocks={ ALLOWED_BLOCKS }
+						templateInsertUpdatesSelection={ false }
 					/>
 				</div>
 			</Fragment>

--- a/src/blocks/row/components/edit.js
+++ b/src/blocks/row/components/edit.js
@@ -330,7 +330,8 @@ class Edit extends Component {
 						<InnerBlocks
 							template={ TEMPLATE[ layout ] }
 							templateLock="all"
-							allowedBlocks={ ALLOWED_BLOCKS } />
+							allowedBlocks={ ALLOWED_BLOCKS }
+							templateInsertUpdatesSelection={ false } />
 					</div>
 				</div>
 			</Fragment>


### PR DESCRIPTION
Makes sure that when we insert an InnerBlocks block, the parent block gets selected instead of its child getting the selection right away.