### PR TITLE
Lowers the z-index so that the block is not over the top toolbar

### DIFF
--- a/src/extensions/advanced-controls/styles/editor.scss
+++ b/src/extensions/advanced-controls/styles/editor.scss
@@ -47,7 +47,7 @@
 			&.is-selected {
 				&[data-no-top-margin="1"],
 				&[data-no-bottom-margin="1"] {
-					z-index: 90;
+					z-index: 29;
 				}
 			}
 		}


### PR DESCRIPTION
But keeps it high enough to keep the resizable handle visible.