### PR TITLE
Fix the icon color within the transforms UI

### DIFF
--- a/src/styles/editor/_icons.scss
+++ b/src/styles/editor/_icons.scss
@@ -11,9 +11,9 @@
 
 // Style our custom colored icons like the default icons.
 .coblocks__svg {
-
 	.components-panel &,
 	.components-toolbar &,
+	.editor-block-types-list &,
 	.editor-block-navigation__item & {
 		color: $dark-gray-500;
 	}


### PR DESCRIPTION
I think it's better for our custom block icon UI to be removed in places like this, so that they fit into the UI better.

<img width="528" alt="screenshot 2019-01-24 11 37 53" src="https://user-images.githubusercontent.com/1813435/51693217-85cb6680-1fcc-11e9-92d9-532dbef3a179.png">
